### PR TITLE
add WithPrintfLogger convenience option

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package proteus_test
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/simplesurance/proteus"
@@ -15,7 +16,7 @@ func Example() {
 		Port: 5432,
 	}
 
-	parsed, err := proteus.MustParse(&params)
+	parsed, err := proteus.MustParse(&params, proteus.WithPrintfLogger(log.Printf))
 	if err != nil {
 		parsed.ErrUsage(os.Stderr, err)
 		os.Exit(1)

--- a/example_test.go
+++ b/example_test.go
@@ -2,7 +2,6 @@ package proteus_test
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/simplesurance/proteus"
@@ -16,7 +15,7 @@ func Example() {
 		Port: 5432,
 	}
 
-	parsed, err := proteus.MustParse(&params, proteus.WithPrintfLogger(log.Printf))
+	parsed, err := proteus.MustParse(&params)
 	if err != nil {
 		parsed.ErrUsage(os.Stderr, err)
 		os.Exit(1)

--- a/options.go
+++ b/options.go
@@ -65,3 +65,13 @@ func WithLogger(l plog.Logger) Option {
 		p.loggerFn = l
 	}
 }
+
+// WithPrintfLogger use the printf-style logFn function as logger.
+func WithPrintfLogger(logFn func(format string, v ...any)) Option {
+	return func(p *settings) {
+		p.loggerFn = func(e plog.Entry) {
+			logFn("%-5s %s:%d %s\n",
+				e.Severity, e.Caller.File, e.Caller.LineNumber, e.Message)
+		}
+	}
+}


### PR DESCRIPTION
To make it simple to use a standard printf-style function, like log.Printf  as logger, 
add a WithPrintfLogger() option that wraps the passed
printf function to be compatible with  plog.Logger.