### PR TITLE
xtypes: fixing issues with default values

### DIFF
--- a/dynamic_test.go
+++ b/dynamic_test.go
@@ -73,12 +73,14 @@ func TestDynamic(t *testing.T) {
 	for ix, value := range wantedValues[1:] {
 		t.Logf("Done waiting for callback; requesting dynamic value update with value %q", value)
 
-		// Update the value is assert that the new value is visible. The test code
-		// here will update the value in one routine while reading it on a busy
-		// loop to allow the race detector to find concurrency issues.
-		go func() {
-			provider.Update("", "x", value)
-		}()
+		// Change the value in one routine and assert that the new value is
+		// visible on another. The read happens on a busy loop. This is to
+		// maximize the chance of the go race detector to find issues with the
+		// code.
+		go func(value string) {
+			time.Sleep(100 * time.Millisecond)
+			provider.Update("", "x", &value)
+		}(value)
 
 		start := time.Now()
 		for i := 0; ; i++ {

--- a/parsed.go
+++ b/parsed.go
@@ -168,7 +168,7 @@ func (p *Parsed) Stop() {
 
 // validateAllXtypesDefaultValues test if all optional parameters specified
 // using an xtype have a valid default value.
-func (p *Parsed) validateAllXtypesDefaultValues() error {
+func (p *Parsed) validateXTypeOptionalDefaults() error {
 	violations := types.ErrViolations{}
 
 	for _, set := range p.inferedConfig {

--- a/parsed.go
+++ b/parsed.go
@@ -166,7 +166,7 @@ func (p *Parsed) Stop() {
 	}
 }
 
-// validateAllXtypesDefaultValues test if all optional parameters specified
+// validateAllXtypesDefaultValues tests if all optional parameters specified
 // using an xtype have a valid default value.
 func (p *Parsed) validateXTypeOptionalDefaults() error {
 	violations := types.ErrViolations{}

--- a/parsed.go
+++ b/parsed.go
@@ -176,12 +176,7 @@ func (p *Parsed) valid() error {
 		for paramName, paramConfig := range set.fields {
 			// must validate when a value is present and when it
 			// is missing (value=nil)
-			var value *string
-			if setValues, ok := mergedValues[setName]; ok {
-				if paramValue, ok := setValues[paramName]; ok {
-					value = &paramValue
-				}
-			}
+			value := mergedValues.Get(setName, paramName)
 
 			if err := p.validValue(setName, paramName, value); err != nil {
 				var validViol types.ErrViolations
@@ -247,13 +242,10 @@ func (p *Parsed) validValue(setName, paramName string, value *string) error {
 
 	if value == nil {
 		if !param.optional {
-			return types.ErrViolations([]types.Violation{
-				{
-					SetName:   setName,
-					ParamName: paramName,
-					Message:   "parameter is required but was not specified",
-				},
-			})
+			return types.ErrViolations([]types.Violation{{
+				SetName:   setName,
+				ParamName: paramName,
+				Message:   "parameter is required but was not specified"}})
 		}
 
 		return nil
@@ -261,14 +253,11 @@ func (p *Parsed) validValue(setName, paramName string, value *string) error {
 
 	err := param.validFn(*value)
 	if err != nil {
-		return types.ErrViolations([]types.Violation{
-			{
-				SetName:   setName,
-				ParamName: paramName,
-				ValueFn:   param.redactedValue(value),
-				Message:   err.Error(),
-			},
-		})
+		return types.ErrViolations([]types.Violation{{
+			SetName:   setName,
+			ParamName: paramName,
+			ValueFn:   param.redactedValue(value),
+			Message:   err.Error()}})
 	}
 
 	return nil

--- a/parser.go
+++ b/parser.go
@@ -161,7 +161,7 @@ func MustParse(config any, options ...Option) (*Parsed, error) {
 	}
 
 	// all optional xtypes must have valid default values
-	err = ret.validateAllXtypesDefaultValues()
+	err = ret.validateXTypeOptionalDefaults()
 	if err != nil {
 		panic(fmt.Errorf("INVALID USAGE OF XTYPE: %v", err))
 	}

--- a/parser.go
+++ b/parser.go
@@ -392,6 +392,7 @@ func parseParam(structField reflect.StructField, fieldVal reflect.Value) (
 		}
 
 		ret.boolean = describeType(fieldVal) == "bool"
+		ret.typ = describeType(fieldVal)
 
 		ret.validFn = toXType(fieldVal).ValueValid
 		ret.setValueFn = toXType(fieldVal).UnmarshalParam
@@ -407,8 +408,6 @@ func parseParam(structField reflect.StructField, fieldVal reflect.Value) (
 
 		return paramName, ret, nil
 	}
-
-	ret.typ = describeType(fieldVal)
 
 	// if is a struct, assume it to be a parameter set
 	if fieldVal.Kind() == reflect.Struct {

--- a/parser.go
+++ b/parser.go
@@ -160,6 +160,12 @@ func MustParse(config any, options ...Option) (*Parsed, error) {
 		return &ret, err
 	}
 
+	// all optional xtypes must have valid default values
+	err = ret.validateAllXtypesDefaultValues()
+	if err != nil {
+		panic(fmt.Errorf("INVALID USAGE OF XTYPE: %v", err))
+	}
+
 	// start watching each configuration item on each provider
 	updaters := make([]*updater, len(opts.providers))
 	for ix, provider := range opts.providers {
@@ -251,6 +257,8 @@ func inferConfigFromValue(value any, opts settings) (config, error) {
 					name, consts.ParamNameRE)})
 		}
 
+		tag.path = member.Path
+
 		if tag.paramSet {
 			// is a set or parameters
 			d, err := parseParamSet(name, member.Path, member.value)
@@ -339,7 +347,6 @@ func parseParam(structField reflect.StructField, fieldVal reflect.Value) (
 	paramName = tagParamParts[0]
 
 	ret := paramSetField{
-		typ:  describeType(fieldVal),
 		desc: structField.Tag.Get("param_desc"),
 	}
 
@@ -367,6 +374,7 @@ func parseParam(structField reflect.StructField, fieldVal reflect.Value) (
 	// try to configure it as a "basic type"
 	err := configStandardCallbacks(&ret, fieldVal)
 	if err == nil {
+		ret.typ = describeType(fieldVal)
 		return paramName, ret, nil
 	}
 
@@ -399,6 +407,8 @@ func parseParam(structField reflect.StructField, fieldVal reflect.Value) (
 
 		return paramName, ret, nil
 	}
+
+	ret.typ = describeType(fieldVal)
 
 	// if is a struct, assume it to be a parameter set
 	if fieldVal.Kind() == reflect.Struct {

--- a/plog/logger.go
+++ b/plog/logger.go
@@ -29,7 +29,7 @@ func (logger Logger) I(msg string, opts ...Option) {
 func (logger Logger) E(msg string, opts ...Option) {
 	o := applyOptions(opts...)
 	logger(Entry{
-		Severity: SevInfo,
+		Severity: SevError,
 		Message:  msg,
 		Caller:   ReadCaller(o.skipCallers),
 	})

--- a/plog/testlogger.go
+++ b/plog/testlogger.go
@@ -11,6 +11,11 @@ func TestLogger(t *testing.T) Logger {
 		t.Helper()
 
 		j, _ := json.MarshalIndent(e, "", "  ")
-		t.Logf("%s", j)
+
+		if e.Severity == SevError {
+			t.Errorf("test produced a log entry with error severity: %s", j)
+		} else {
+			t.Logf("%s", j)
+		}
 	}
 }

--- a/sources/cfgtest/cfgtest.go
+++ b/sources/cfgtest/cfgtest.go
@@ -42,7 +42,7 @@ func (r *TestProvider) IsCommandLineFlag() bool {
 
 // Update changes a value on the test provider, allowing for test on
 // hot-reloading of parameters.
-func (r *TestProvider) Update(setid, id string, value string) {
+func (r *TestProvider) Update(setid, id string, value *string) {
 	valuesCopy := func() types.ParamValues {
 		r.protected.mutex.Lock()
 		defer r.protected.mutex.Unlock()
@@ -53,7 +53,14 @@ func (r *TestProvider) Update(setid, id string, value string) {
 			r.protected.values[setid] = set
 		}
 
-		set[id] = value
+		if value == nil {
+			delete(set, id)
+			if len(set) == 0 {
+				delete(r.protected.values, setid)
+			}
+		} else {
+			set[id] = *value
+		}
 
 		return r.protected.values.Copy()
 	}()

--- a/type_walker.go
+++ b/type_walker.go
@@ -29,7 +29,7 @@ func flatWalk(setName, setPath string, val reflect.Value) (map[string]fieldAndVa
 		for i := 0; i < val.NumField(); i++ {
 			field := val.Type().Field(i)
 			fieldValue := val.Field(i)
-			path := path + "/" + field.Name
+			path := strings.TrimPrefix(path+"/"+field.Name, "/")
 
 			if field.Type.Kind() == reflect.Struct && field.Anonymous {
 				walker(fieldValue, path)

--- a/types/violation.go
+++ b/types/violation.go
@@ -44,6 +44,13 @@ func (e ErrViolations) Error() string {
 }
 
 // Violation holds a single violation of the requirements for parameters.
+//
+// Callers should either provide "Path" or provide Set and Param names:
+//
+//   - Path is preferable when the violation is caused by an incorrect
+//     parameter struct, like for example using an unsupported type
+//   - SetName+ParamName should be used when the parameter struct itself is
+//     correct, so the problem lies somewhere else.
 type Violation struct {
 	// Path identifies the location of a violation on the configuration
 	// struct.
@@ -67,18 +74,22 @@ type Violation struct {
 
 func (v Violation) String() string {
 	var id string
+	var idtype string
 
 	if v.Path != "" {
+		idtype = "configuration struct element"
 		id = v.Path
 	} else if v.SetName != "" {
+		idtype = "parameter"
 		id = v.SetName + "." + v.ParamName
 	} else {
+		idtype = "parameter"
 		id = v.ParamName
 	}
 
 	if v.ValueFn == nil {
-		return fmt.Sprintf("%q: %s", id, v.Message)
+		return fmt.Sprintf("%s %q: %s", idtype, id, v.Message)
 	}
 
-	return fmt.Sprintf("%q: %s (parsing %q)", id, v.Message, v.ValueFn())
+	return fmt.Sprintf("parameter %q: %s (parsing %q)", id, v.Message, v.ValueFn())
 }

--- a/xtypes/oneof.go
+++ b/xtypes/oneof.go
@@ -13,14 +13,32 @@ import (
 // OneOf is a parameter configuration that can hold a value from a list of
 // valid options. The list of options must be provided. An UpdateFn can be
 // provided to be notified about changes to the value.
+//
+// The list of choices is mandatory, and must be provided in the "Choices"
+// field.
+//
+// If the parameter is not optional it is mandatory to provide a default
+// value that matches one of the choices. For mandatory parameters, a
+// default value don't have to be provided, and is ignored.
+//
+// Example:
+//
+//	params := struct{
+//		Region: *xtypes.OneOf
+//	}{
+//		Region: &xtypes.OneOf{
+//			Choices:      []string{"EU", "US"},
+//			DefaultValue: "EU",
+//		},
+//	}
 type OneOf struct {
 	Choices      []string
 	DefaultValue string
 	IgnoreCase   bool
 	UpdateFn     func(string)
 	content      struct {
-		valueIx *int
-		mutex   sync.Mutex
+		value *string
+		mutex sync.Mutex
 	}
 }
 
@@ -30,24 +48,26 @@ var _ types.TypeDescriber = &OneOf{}
 // UnmarshalParam is a custom parser for a string parameter. This will always
 // run on brand new instance of string, so no synchronization is necessary.
 func (d *OneOf) UnmarshalParam(in *string) error {
-	var valueIxPtr *int
+	var newValue *string
 	if in != nil {
-		for ix, opt := range d.Choices {
+		ok := false
+		for _, opt := range d.Choices {
 			if d.compare(opt, *in) {
-				cpix := ix
-				valueIxPtr = &cpix
+				ok = true
+				cpin := *in
+				newValue = &cpin
 				break
 			}
 		}
-	}
 
-	if valueIxPtr == nil {
-		return errors.New("value must be one of: " +
-			strings.Join(d.Choices, "|"))
+		if !ok {
+			return errors.New("value must be one of: " +
+				strings.Join(d.Choices, "|"))
+		}
 	}
 
 	d.content.mutex.Lock()
-	d.content.valueIx = valueIxPtr
+	d.content.value = newValue
 	d.content.mutex.Unlock()
 
 	if d.UpdateFn != nil {
@@ -62,11 +82,11 @@ func (d *OneOf) Value() string {
 	d.content.mutex.Lock()
 	defer d.content.mutex.Unlock()
 
-	if d.content.valueIx == nil {
+	if d.content.value == nil {
 		return d.DefaultValue
 	}
 
-	return d.Choices[*d.content.valueIx]
+	return *d.content.value
 }
 
 // ValueValid test if the provided parameter value is valid. Has no side
@@ -90,8 +110,8 @@ func (d *OneOf) GetDefaultValue() (string, error) {
 	}
 
 	return "", fmt.Errorf(
-		"provided default value is not on the list of choices [%s]",
-		strings.Join(d.Choices, ", "))
+		"default value for OneOf is not on the list of choices [%s]",
+		strings.Join(d.Choices, "|"))
 }
 
 // DescribeType changes how usage information is shown for parameters

--- a/xtypes/oneof.go
+++ b/xtypes/oneof.go
@@ -110,7 +110,7 @@ func (d *OneOf) GetDefaultValue() (string, error) {
 	}
 
 	return "", fmt.Errorf(
-		"default value for OneOf is not on the list of choices [%s]",
+		"default value for OneOf is not in the list of choices [%s]",
 		strings.Join(d.Choices, "|"))
 }
 


### PR DESCRIPTION
Some XTypes, like `xtypes.OneOf`, might require a default value to be specified for mandatory parameters. If for example the list of choices is _do_, _re_, _mi_ and the parameter is marked as optional, then the default value must be one of the provided values. If the parameter is not optional, then the default value will not be used, meaning that it doesn't mater what the value is. The logic for handling this condition existed, but it was not correct. The test provider, for example, only supported setting a parameter, but not _unsetting_ it.

A second problem solved on this PR is that an optional XType might have a value, then the value might stop being provided (for example, a file that provides the value is deleted). In this case, the value must changed back to the default value. This condition was also covered by code, but it was not working correctly.

Finally, a log message was being shown every time the value of a parameter configured using OneOf was being used.  It was also calling the _E_ (error) helper function, but that was logging it as _info_. The log message caused no side effects, but was confusing.

This PR fixes the issues above by:

- Validating the default values for all optional parameter provided using xtypes. This condition is a coding error, so is handled by panicking `MustParse`. Test coverage is included.
- Test provider now supports unsetting a parameter, and a test for reverting to default was included;
- The test logger was changed to cause the test to fail if a log message with severity _error_ is logged.

The issues fixed by this PR, except by the log message, affected only dynamic providers, which are not merged yet.