### PR TITLE
documentation: using latest on go get instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ guaranteed.
 ## How to Get
 
 ```bash
-go get github.com/simplesurance/proteuslatest
+go get github.com/simplesurance/proteus@latest
 ```
 
 ## How to Use

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ guaranteed.
 ## How to Get
 
 ```bash
-go get github.com/simplesurance/proteus@v0.0.2
+go get github.com/simplesurance/proteuslatest
 ```
 
 ## How to Use


### PR DESCRIPTION
In the instructions to _go get_ proteus on README.md a fixed version is being used. Currently manually editing the file is necessary. Until an automated method is put in place, use instead @latest.