### PR TITLE
options: implementing dry-mode

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -470,7 +470,30 @@ func addSpecialFlags(appConfig config, parsed *Parsed, opts settings) error {
 		}
 	}
 
-	// TODO: support --dry-mode
+	if opts.autoDryModeFn != nil {
+		appConfig[""].fields["dry-mode"] = paramSetField{
+			typ:       "bool",
+			optional:  true,
+			desc:      "Validates all other parameters and exit",
+			boolean:   true,
+			isSpecial: true,
+
+			// when the --help flag is provided, the parsed object will
+			// try to determine if the value is valid. Generate the
+			// help usage instead of terminate the application.
+			validFn: func(v string) error {
+				parsed.Usage(opts.autoUsageWriter)
+				parsed.settings.autoUsageExitFn()
+
+				fmt.Fprintln(opts.autoUsageWriter, "WARNING: the provided termination function did not terminated the application")
+				os.Exit(0)
+				return nil
+			},
+			setValueFn:   func(_ *string) error { return nil },
+			getDefaultFn: func() (string, error) { return "false", nil },
+			redactFn:     func(s string) string { return s },
+		}
+	}
 
 	if len(violations) > 0 {
 		return nil


### PR DESCRIPTION
Implement support for `--dry-mode` flag, which will validate all other parameters and exit. A callback function must be provided to specify what to do after validation. This callback function have access to the `Parsed` object, which allows getting information about the validation errors, and can be used to exit with any specific code.

Closes #5