### PR TITLE
options: introduce WithValueFormatting option

### DIFF
--- a/mustparse_test.go
+++ b/mustparse_test.go
@@ -64,3 +64,31 @@ func ExampleMustParse_providers() {
 
 	fmt.Printf("Server: %s:%d\n", params.Server, params.Port)
 }
+
+// ExampleMustParse_trimSpaces instructs proteus to trim values of parameters,
+// removing leading and trailing spaces. This also removes trailing new lines.
+func ExampleMustParse_trimSpaces() {
+	params := struct {
+		Server string
+		Port   uint16
+	}{}
+
+	parsed, err := proteus.MustParse(&params,
+		proteus.WithValueFormatting(proteus.ValueFormattingOptions{
+			TrimSpace: true,
+		}))
+	if err != nil {
+		parsed.ErrUsage(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Server: %s:%d\n", params.Server, params.Port)
+
+	// Calling with:
+	//
+	//   ./app -server "localhost" -port "8080"
+	//
+	// is the same as:
+	//
+	//   ./app -server " localhost \n" -port "8080\n"
+}

--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package proteus
 
 import (
 	"io"
+	"strings"
 
 	"github.com/simplesurance/proteus/plog"
 	"github.com/simplesurance/proteus/sources"
@@ -11,9 +12,10 @@ import (
 type Option func(*settings)
 
 type settings struct {
-	providers   []sources.Provider
-	loggerFn    plog.Logger
-	onelineDesc string
+	providers       []sources.Provider
+	loggerFn        plog.Logger
+	onelineDesc     string
+	valueFormatting ValueFormattingOptions
 
 	// auto-usage (aka --help)
 	autoUsageExitFn func()
@@ -74,4 +76,27 @@ func WithPrintfLogger(logFn func(format string, v ...any)) Option {
 				e.Severity, e.Caller.File, e.Caller.LineNumber, e.Message)
 		}
 	}
+}
+
+// WithValueFormatting specifies options for pre-processing values before
+// using them. See ValueFormattingOptions for more details.
+func WithValueFormatting(o ValueFormattingOptions) Option {
+	return func(p *settings) {
+		p.valueFormatting = o
+	}
+}
+
+// ValueFormattingOptions specifies how values of parameters are "trimmed".
+type ValueFormattingOptions struct {
+	// TrimSpace instructs proteus to trim leading and trailing spaces from
+	// values of parameters.
+	TrimSpace bool
+}
+
+func (t ValueFormattingOptions) apply(v string) string {
+	if t.TrimSpace {
+		v = strings.TrimSpace(v)
+	}
+
+	return v
 }

--- a/updater.go
+++ b/updater.go
@@ -55,6 +55,14 @@ func (u *updater) Peek(setName, paramName string) (*string, error) {
 }
 
 func (u *updater) update(v types.ParamValues, refresh bool) {
+	v = v.Copy()
+
+	for _, set := range v {
+		for paramName, paramValue := range set {
+			set[paramName] = u.parsed.settings.valueFormatting.apply(paramValue)
+		}
+	}
+
 	u.mustBeOnValidIDs(v)
 	u.validateValues(v)
 


### PR DESCRIPTION
This PR introduces an option called WithValueFormatting. It allows specifying options for pre-processing values before they get used. The initial supported feature is trimming values.

This is useful for some cases where the value of the parameters contains undesired spaces, like when a bad templating language is used for providing values, leading to undesired spaces or even trailing new line.