### PR TITLE
doc: removing test coverage badge because it is no longer being updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Proteus
-![Coverage](https://img.shields.io/badge/Coverage-58.4%25-yellow)
 [![Go Report Card](https://goreportcard.com/badge/github.com/simplesurance/proteus)](https://goreportcard.com/report/github.com/simplesurance/proteus)
 
 ## About


### PR DESCRIPTION
Removing the test coverage report badge, because the code that updated it was
removed.