### PR TITLE
do not print help output on usage error

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -457,6 +457,7 @@ func addSpecialFlags(appConfig config, parsed *Parsed, opts settings) error {
 				// help usage instead of terminate the application.
 				validFn: func(v string) error {
 					parsed.Usage(opts.autoUsageWriter)
+					parsed.help(opts.autoUsageWriter)
 					parsed.settings.autoUsageExitFn()
 
 					fmt.Fprintln(opts.autoUsageWriter, "WARNING: the provided termination function did not terminated the application")


### PR DESCRIPTION
When an error happened, like a required parmameter was not passed, Proteus was printing a usage description and help text.

If an application had a lot of parameter the help output was very long and made it hard to find the actual error.
In most circumstances the short usage description is sufficient to figure what the application expect.

- split printing the usage and help output into 2 functions, add a Help() function,
- do not print the long parameter description when parsed.ErrUsage() is called
- move some code that is shared between Usage() and Help() to helper functions, to reduce duplication