### PR TITLE
reduce newlines in the usage output

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ func main() {
 	}
 
 	parsed, err := proteus.MustParse(&params,
-		proteus.WithAutoUsage(os.Stderr, "Demo App", func() { os.Exit(0) }))
+		proteus.WithAutoUsage(os.Stderr, func() { os.Exit(0) }))
 	if err != nil {
 		parsed.WriteError(os.Stderr, err)
 		os.Exit(1)

--- a/README.md
+++ b/README.md
@@ -239,17 +239,9 @@ go run main.go --help
 # - "database.password": parameter is required but was not specified
 # - "database.user": parameter is required but was not specified
 #
-#
-# Usage:
-# app \
-#     [-help] \
-#     -environment <dev|stg|prd> \
-#     -port <uint16> \
-#   database \
-#     -password <string> \
-#     -user <string> \
-#     [-port <uint16>] \
-#     [-server <string>]
+# Usage: main [-help] -environment <dev|stg|prd> -port <uint16>
+#                     database -password <string> -user <string> [-port <uint16>]
+#                              [-server <string>]
 #
 # PARAMETERS
 # - help default=false

--- a/example_usage_test.go
+++ b/example_usage_test.go
@@ -20,11 +20,7 @@ func ExampleParsed_Usage() {
 	parsed.Usage(os.Stdout)
 
 	// Output:
-	// Usage:
-	// proteus.test \
-	//     [-help] \
-	//     -server <string> \
-	//     [-port <uint16>]
+	// Usage: proteus.test [-help] -server <string> [-port <uint16>]
 	//
 	// PARAMETERS
 	// - help default=false

--- a/parsed.go
+++ b/parsed.go
@@ -379,8 +379,7 @@ func (p *Parsed) desiredValue(setName, paramName string) *string {
 }
 
 func binaryName() string {
-	_, ret := filepath.Split(os.Args[0])
-	return ret
+	return filepath.Base(os.Args[0])
 }
 
 func formatCmdLineParam(cmd string, field paramSetField) string {


### PR DESCRIPTION
```
reduce newlines in the usage output

In the usage output each set name and parameter name was printed on a new line.
The output got very long with many parameters.

Make the output more compact by only splitting lines per set parameter or when a
line would contain more then 79 chars.

This format is more compact and easier to read.

-------------------------------------------------------------------------------
replace filepath.Split with filepath.Base in binaryName()

It's more simple and filepath.Base() does exactly what is wanted.

-------------------------------------------------------------------------------

readme: fix: remove passing app name to WithAutoUsage()

The parameter was removed from WithAutoUsage(), remove it also from the code
example in the readme.

-------------------------------------------------------------------------------
```