### PR TITLE
options: add support for --version

### DIFF
--- a/options.go
+++ b/options.go
@@ -20,6 +20,9 @@ type settings struct {
 	// auto-usage (aka --help)
 	autoUsageExitFn func()
 	autoUsageWriter io.Writer
+
+	// version (aka --version)
+	version string
 }
 
 func (s *settings) apply(options ...Option) {
@@ -83,6 +86,12 @@ func WithPrintfLogger(logFn func(format string, v ...any)) Option {
 func WithValueFormatting(o ValueFormattingOptions) Option {
 	return func(p *settings) {
 		p.valueFormatting = o
+	}
+}
+
+func WithVersion(version string) Option {
+	return func(s *settings) {
+		s.version = version
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -455,7 +455,7 @@ func addSpecialFlags(appConfig config, parsed *Parsed, opts settings) error {
 				// parsed object will try to determine if the
 				// value is valid. Show the version instead.
 				validFn: func(v string) error {
-					fmt.Fprintln(os.Stdout, opts.version)
+					fmt.Println(opts.version)
 					os.Exit(0)
 					return nil
 				},

--- a/parser.go
+++ b/parser.go
@@ -433,6 +433,39 @@ func parseParam(structField reflect.StructField, fieldVal reflect.Value) (
 func addSpecialFlags(appConfig config, parsed *Parsed, opts settings) error {
 	var violations types.ErrViolations
 
+	if opts.version != "" {
+		const versionFlagName = "version"
+		const versionFlagDescription = "Prints the application version to stdout"
+
+		if conflictingVersionParam, exits := appConfig.getParam("", versionFlagName); exits {
+			violations = append(violations, types.Violation{
+				ParamName: versionFlagName,
+				Path:      conflictingVersionParam.path,
+				Message:   `Must not register a parameter called "version" when the version is provided to proteus, since this flag is registered automatically`,
+			})
+		} else {
+			appConfig[""].fields[versionFlagName] = paramSetField{
+				typ:       "bool",
+				optional:  true,
+				desc:      versionFlagDescription,
+				boolean:   true,
+				isSpecial: true,
+
+				// when the --version flag is provided, the
+				// parsed object will try to determine if the
+				// value is valid. Show the version instead.
+				validFn: func(v string) error {
+					fmt.Fprintln(os.Stdout, opts.version)
+					os.Exit(0)
+					return nil
+				},
+				setValueFn:   func(_ *string) error { return nil },
+				getDefaultFn: func() (string, error) { return "false", nil },
+				redactFn:     func(s string) string { return s },
+			}
+		}
+	}
+
 	// --help
 	if opts.autoUsageExitFn != nil {
 		helpFlagName := "help"
@@ -442,7 +475,7 @@ func addSpecialFlags(appConfig config, parsed *Parsed, opts settings) error {
 			violations = append(violations, types.Violation{
 				ParamName: helpFlagName,
 				Path:      conflictingParam.path,
-				Message:   "The help parameter cannot be used when the auto-usage is requested",
+				Message:   `Must not register a parameter called "help" when the auto-usage is requested`,
 			})
 		} else {
 			appConfig[""].fields[helpFlagName] = paramSetField{

--- a/types.go
+++ b/types.go
@@ -55,7 +55,7 @@ type paramSetField struct {
 	path     string
 
 	// isSpecial specifies that the parameter cannot be specified by all
-	// providers, line --help.
+	// providers, like --help or --version.
 	isSpecial bool
 
 	isXtype      bool // implements the types.XType interface


### PR DESCRIPTION
A new option called WithVersion was added. If provided, a flag --version will be registered. If invoked, it will write the version to stdout followed by a new line.