### PR TITLE
bugfix: panic if ignored field has unsupported type

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -350,6 +350,10 @@ func parseParam(structField reflect.StructField, fieldVal reflect.Value) (
 		desc: structField.Tag.Get("param_desc"),
 	}
 
+	if paramName == "-" {
+		return paramName, ret, nil
+	}
+
 	for _, tagOption := range tagParamParts[1:] {
 		switch tagOption {
 		case "optional":

--- a/parser_test.go
+++ b/parser_test.go
@@ -240,6 +240,30 @@ func TestParseWithTrim(t *testing.T) {
 	assert.Equal(t, "https://localhost", params.TestURL.Value().String())
 }
 
+func TestIgnoreInvalidMember(t *testing.T) {
+	testWriter := testWriter{t}
+
+	params := struct {
+		A int    `param:",optional"`
+		B func() `param:"-"`
+	}{}
+
+	testProvider := cfgtest.New(types.ParamValues{"": map[string]string{}})
+
+	defer testProvider.Stop()
+
+	parsed, err := proteus.MustParse(&params,
+		proteus.WithProviders(testProvider),
+		proteus.WithLogger(plog.TestLogger(t)))
+	if err != nil {
+		t.Logf("Unexpected error parsing configuration: %+v", err)
+		parsed.WriteError(testWriter, err)
+		t.FailNow()
+	}
+
+	t.Logf("Configuration field successfully ignored")
+}
+
 type testWriter struct {
 	t *testing.T
 }


### PR DESCRIPTION
A configuration struct may contain some fields that are not intended to be used for configuration. Those fields can be marked with the name "-", like:

```go
cfg := struct{
    A string
    B func() `param:"-"` // ignore: not a parameter
}{}
```

When this case was used on proteus would check the type of the struct before checking the name, resulting in a panic about configuration error on the field B.

This PR fixes the issue by correctly checking if the fields is ignored before looking into the field type. A test is included to avoid regression.