### PR TITLE
feature: adding support for time.Time and time.Duration fields

### DIFF
--- a/internal/assert/equals.go
+++ b/internal/assert/equals.go
@@ -24,3 +24,27 @@ func Equal[T comparable](t testing.TB, a, b T) bool {
 	t.Errorf("Values should be equal, but they aren't:\nA: %v\nB: %v", a, b)
 	return false
 }
+
+// EqualNowFn asserts that a.Equals(b).
+func EqualNowFn[T any](t testing.TB, a, b T) {
+	t.Helper()
+
+	if !EqualFn[T](t, a, b) {
+		t.FailNow()
+	}
+}
+
+// EqualFn asserts that "a" is equals to "b" by calling a.Equal(b).
+// Returns true if assertion passes.
+func EqualFn[T any](t testing.TB, a any, b T) bool {
+	t.Helper()
+
+	eqIf := a.(interface{ Equal(other T) bool })
+
+	if eqIf.Equal(b) {
+		return true
+	}
+
+	t.Errorf("Values should be equal, but they aren't:\nA: %v\nB: %v", a, b)
+	return false
+}


### PR DESCRIPTION
Adding support for struct fields of type `time.Time` and `time.Duration`. Test coverage is included.